### PR TITLE
Refactor to multipage layout with service admin

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>О компании | MoldPro</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container flex-between">
+      <div class="logo">MOLD<span class="accent">PRO</span></div>
+      <nav class="site-nav">
+        <a href="index.html">Главная</a>
+        <a href="services.html">Услуги</a>
+        <a href="about.html">О компании</a>
+        <a href="contacts.html">Контакты</a>
+        <a href="admin.html">Админ</a>
+      </nav>
+      <div class="burger" id="burger">
+        <span></span><span></span><span></span>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="about">
+      <div class="container about-grid">
+        <div class="about-text">
+          <h1 class="section-title">О компании</h1>
+          <p>Мы — команда инженеров‑технологов, конструкторов и операторов ЧПУ, которые более десяти лет помогают производителям перейти от эскиза к серийному изделию. Полностью берём на себя проектирование, производство, запуск и сервис формы.</p>
+          <h3>Наши ресурсы</h3>
+          <ul>
+            <li>5‑осевые обрабатывающие центры (X = 1000 мм), точность 0,005 мм</li>
+            <li>Отдел контроля качества с CMM и рентгеноскопией</li>
+            <li>Склад европейских инструментальных сталей и порошков</li>
+          </ul>
+          <h3>Наша философия</h3>
+          <p>Минимизировать время «идея → серия» и поддерживать форму в рабочем состоянии весь срок службы.</p>
+        </div>
+        <div class="about-photo"><img src="assets/about-placeholder.jpg" alt=""></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-flex">
+      <p>&copy; 2025 MoldPro. Все права защищены.</p>
+      <a href="#">Политика конфиденциальности</a>
+      <a href="tel:+7XXXXXXXXXX" class="footer-call btn accent">Позвонить</a>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Админ | MoldPro</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container flex-between">
+      <div class="logo">MOLD<span class="accent">PRO</span></div>
+      <nav class="site-nav">
+        <a href="index.html">Главная</a>
+        <a href="services.html">Услуги</a>
+        <a href="about.html">О компании</a>
+        <a href="contacts.html">Контакты</a>
+        <a href="admin.html">Админ</a>
+      </nav>
+      <div class="burger" id="burger">
+        <span></span><span></span><span></span>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="services">
+      <div class="container">
+        <h1 class="section-title">Добавить услугу</h1>
+        <form id="serviceForm" class="contact-form">
+          <label>Название<input type="text" name="title" required></label>
+          <label>Описание<textarea name="description" rows="3" required></textarea></label>
+          <button type="submit" class="btn accent">Сохранить</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-flex">
+      <p>&copy; 2025 MoldPro. Все права защищены.</p>
+      <a href="#">Политика конфиденциальности</a>
+      <a href="tel:+7XXXXXXXXXX" class="footer-call btn accent">Позвонить</a>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/contacts.html
+++ b/contacts.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Контакты | MoldPro</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container flex-between">
+      <div class="logo">MOLD<span class="accent">PRO</span></div>
+      <nav class="site-nav">
+        <a href="index.html">Главная</a>
+        <a href="services.html">Услуги</a>
+        <a href="about.html">О компании</a>
+        <a href="contacts.html">Контакты</a>
+        <a href="admin.html">Админ</a>
+      </nav>
+      <div class="burger" id="burger">
+        <span></span><span></span><span></span>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="contacts">
+      <div class="container contact-grid">
+        <div class="contact-info">
+          <h1 class="section-title">Контакты</h1>
+          <p class="accent-text big">Получите расчёт стоимости за 24&nbsp;часа</p>
+          <ul>
+            <li><strong>Тел.:</strong> +7&nbsp;___&nbsp;___‑__‑__</li>
+            <li><strong>E‑mail:</strong> info@_____.ru</li>
+            <li><strong>Адрес производства:</strong> г.&nbsp;___, ул.&nbsp;___, д.&nbsp;___</li>
+            <li><strong>Время работы:</strong> Пн‑Пт 09:00‑18:00 (UTC+3)</li>
+          </ul>
+          <p>Напишите в <a href="#">WhatsApp</a> или <a href="#">Telegram</a> @_______ и прикрепите 3D‑модель для ускоренного расчёта.</p>
+        </div>
+        <form class="contact-form" id="quote">
+          <h3>Запросить расчёт</h3>
+          <label>Имя<input type="text" name="name" required></label>
+          <label>Телефон<input type="tel" name="phone" required></label>
+          <label>E‑mail<input type="email" name="email" required></label>
+          <label>Сообщение<textarea name="message" rows="4"></textarea></label>
+          <label class="file-label">
+            Прикрепить файл
+            <input type="file" name="file">
+          </label>
+          <button type="submit" class="btn accent">Отправить</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-flex">
+      <p>&copy; 2025 MoldPro. Все права защищены.</p>
+      <a href="#">Политика конфиденциальности</a>
+      <a href="tel:+7XXXXXXXXXX" class="footer-call btn accent">Позвонить</a>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
     <div class="container flex-between">
       <div class="logo">MOLD<span class="accent">PRO</span></div>
       <nav class="site-nav">
-        <a href="#services">Услуги</a>
-        <a href="#about">О компании</a>
-        <a href="#contacts">Контакты</a>
-        <button class="btn accent" data-target="#quote">Запросить расчёт</button>
+        <a href="services.html">Услуги</a>
+        <a href="about.html">О компании</a>
+        <a href="contacts.html">Контакты</a>
+        <a href="admin.html">Админ</a>
       </nav>
       <div class="burger" id="burger">
         <span></span><span></span><span></span>
@@ -35,7 +35,7 @@
     <div class="hero-content container">
       <h1>Прецизионные пресс‑формы <br>и восстановление оснастки</h1>
       <p>От идеи до первых отливок за <strong>5 недель</strong></p>
-      <button class="btn accent" data-target="#quote">Получить расчёт за 24 часа</button>
+      <button class="btn accent" onclick="window.location.href='contacts.html'">Получить расчёт за 24 часа</button>
     </div>
   </section>
 
@@ -48,135 +48,6 @@
     </div>
   </section>
 
-  <!-- Services Section -->
-  <section class="services" id="services">
-    <div class="container">
-      <h2 class="section-title">Наши услуги</h2>
-      <div class="cards">
-        <article class="card">
-          <!-- Replace with your icon -->
-          <div class="card-icon"><img src="assets/service1-placeholder.svg" alt=""></div>
-          <h3>Изготовление пресс‑форм</h3>
-          <p>Полный цикл производства от 3D‑модели до серийного литья.</p>
-          <ul>
-            <li>Срок от 5 недель</li>
-            <li>Гарантия 500&nbsp;000 циклов</li>
-            <li>Стали 1.2083, 1.2344, P20</li>
-          </ul>
-        </article>
-
-        <article class="card">
-          <div class="card-icon"><img src="assets/service2-placeholder.svg" alt=""></div>
-          <h3>Ремонт и обслуживание</h3>
-          <p>Диагностика, дефектовка и восстановление любой оснастки.</p>
-          <ul>
-            <li>TIG‑ и лазерная наплавка</li>
-            <li>Выездные бригады по РФ</li>
-            <li>Антифрикционные покрытия</li>
-          </ul>
-        </article>
-
-        <article class="card">
-          <div class="card-icon"><img src="assets/service3-placeholder.svg" alt=""></div>
-          <h3>Лазерная наплавка</h3>
-          <p>Точечное внесение металла без перекаливания базового слоя.</p>
-          <ul>
-            <li>Сколы до 0,02&nbsp;мм</li>
-            <li>Твёрдость до 60&nbsp;HRC</li>
-            <li>Видеоотчёт процесса</li>
-          </ul>
-        </article>
-      </div>
-    </div>
-  </section>
-
-  <!-- Process Section -->
-  <section class="process">
-    <div class="container">
-      <h2 class="section-title">Как мы работаем</h2>
-      <ol class="steps">
-        <li>Получаем ТЗ и 3D‑модель</li>
-        <li>Проводим литейный анализ</li>
-        <li>Проектируем систему охлаждения</li>
-        <li>Изготавливаем детали на CNC</li>
-        <li>Проводим тестовый холостой выстрел</li>
-        <li>Запускаем форму у клиента</li>
-      </ol>
-    </div>
-  </section>
-
-  <!-- Case Gallery -->
-  <section class="gallery">
-    <div class="container">
-      <h2 class="section-title">Реализованные проекты</h2>
-      <!-- Placeholder slider -->
-      <div class="gallery-slider">
-        <!-- Duplicate slide elements as needed -->
-        <div class="slide">
-          <img src="assets/case-before-placeholder.jpg" alt="До ремонта">
-          <img src="assets/case-after-placeholder.jpg" alt="После ремонта">
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <!-- CTA Band -->
-  <section class="cta-band">
-    <div class="container flex-between">
-      <p>Готовы сократить простой оборудования?</p>
-      <button class="btn accent" data-target="#quote">Запросить калькуляцию</button>
-    </div>
-  </section>
-
-  <!-- About Section -->
-  <section class="about" id="about">
-    <div class="container about-grid">
-      <div class="about-text">
-        <h2 class="section-title">О компании</h2>
-        <p>Мы — команда инженеров‑технологов, конструкторов и операторов ЧПУ, которые более десяти лет помогают производителям перейти от эскиза к серийному изделию. Полностью берём на себя проектирование, производство, запуск и сервис формы.</p>
-        <h3>Наши ресурсы</h3>
-        <ul>
-          <li>5‑осевые обрабатывающие центры (X&nbsp;= 1000&nbsp;мм), точность 0,005&nbsp;мм</li>
-          <li>Отдел контроля качества с CMM и рентгеноскопией</li>
-          <li>Склад европейских инструментальных сталей и порошков</li>
-        </ul>
-        <h3>Наша философия</h3>
-        <p>Минимизировать время «идея → серия» и поддерживать форму в рабочем состоянии весь срок службы.</p>
-      </div>
-      <!-- Replace with your team/facility photo -->
-      <div class="about-photo"><img src="assets/about-placeholder.jpg" alt=""></div>
-    </div>
-  </section>
-
-  <!-- Contact Section -->
-  <section class="contacts" id="contacts">
-    <div class="container contact-grid">
-      <div class="contact-info">
-        <h2 class="section-title">Контакты</h2>
-        <p class="accent-text big">Получите расчёт стоимости за 24&nbsp;часа</p>
-        <ul>
-          <li><strong>Тел.:</strong> +7&nbsp;___&nbsp;___‑__‑__</li>
-          <li><strong>E‑mail:</strong> info@_____.ru</li>
-          <li><strong>Адрес производства:</strong> г.&nbsp;___, ул.&nbsp;___, д.&nbsp;___</li>
-          <li><strong>Время работы:</strong> Пн‑Пт 09:00‑18:00 (UTC+3)</li>
-        </ul>
-        <p>Напишите в <a href="#">WhatsApp</a> или <a href="#">Telegram</a> @_______ и прикрепите 3D‑модель для ускоренного расчёта.</p>
-      </div>
-      <form class="contact-form" id="quote">
-        <h3>Запросить расчёт</h3>
-        <label>Имя<input type="text" name="name" required></label>
-        <label>Телефон<input type="tel" name="phone" required></label>
-        <label>E‑mail<input type="email" name="email" required></label>
-        <label>Сообщение<textarea name="message" rows="4"></textarea></label>
-        <label class="file-label">
-          Прикрепить файл
-          <input type="file" name="file">
-        </label>
-        <button type="submit" class="btn accent">Отправить</button>
-      </form>
-    </div>
-  </section>
-
   <!-- Footer -->
   <footer class="site-footer">
     <div class="container footer-flex">
@@ -185,15 +56,6 @@
       <a href="tel:+7XXXXXXXXXX" class="footer-call btn accent">Позвонить</a>
     </div>
   </footer>
-
-  <!-- Popup -->
-  <div class="popup" id="quotePopup">
-    <div class="popup-content">
-      <button class="popup-close" id="popupClose">&times;</button>
-      <p>Оставьте заявку — мы свяжемся с вами в течение <strong>15 минут</strong></p>
-      <button class="btn accent" data-target="#quote">Получить расчёт</button>
-    </div>
-  </div>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,20 +1,51 @@
 document.addEventListener('DOMContentLoaded', () => {
-  /* Smooth scroll */
-  document.querySelectorAll('[data-target]').forEach(btn => {
-    btn.addEventListener('click', e => {
-      const target = document.querySelector(e.currentTarget.dataset.target);
-      target?.scrollIntoView({ behavior: 'smooth' });
-    });
-  });
-
   /* Mobile nav toggle */
   const burger = document.getElementById('burger');
   const nav = document.querySelector('.site-nav');
   burger?.addEventListener('click', () => nav.classList.toggle('open'));
 
-  /* Popup after 45 seconds */
+  /* Init default services */
+  const defaultServices = [
+    { title: 'Изготовление пресс‑форм', description: 'Полный цикл производства от 3D‑модели до серийного литья.' },
+    { title: 'Ремонт и обслуживание', description: 'Диагностика, дефектовка и восстановление любой оснастки.' },
+    { title: 'Лазерная наплавка', description: 'Точечное внесение металла без перекаливания базового слоя.' }
+  ];
+  if (!localStorage.getItem('services')) {
+    localStorage.setItem('services', JSON.stringify(defaultServices));
+  }
+
+  /* Render services */
+  const list = document.getElementById('servicesList');
+  if (list) {
+    const services = JSON.parse(localStorage.getItem('services')) || [];
+    services.forEach(s => {
+      const card = document.createElement('article');
+      card.className = 'card';
+      card.innerHTML = `<h3>${s.title}</h3><p>${s.description}</p>`;
+      list.appendChild(card);
+    });
+  }
+
+  /* Add service */
+  const form = document.getElementById('serviceForm');
+  if (form) {
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const title = form.title.value.trim();
+      const description = form.description.value.trim();
+      const services = JSON.parse(localStorage.getItem('services')) || [];
+      services.push({ title, description });
+      localStorage.setItem('services', JSON.stringify(services));
+      form.reset();
+      alert('Услуга добавлена');
+    });
+  }
+
+  /* Optional popup */
   const popup = document.getElementById('quotePopup');
   const popupClose = document.getElementById('popupClose');
-  setTimeout(() => popup.classList.add('open'), 45000);
-  popupClose?.addEventListener('click', () => popup.classList.remove('open'));
+  if (popup) {
+    setTimeout(() => popup.classList.add('open'), 45000);
+    popupClose?.addEventListener('click', () => popup.classList.remove('open'));
+  }
 });

--- a/services.html
+++ b/services.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Услуги | MoldPro</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="container flex-between">
+      <div class="logo">MOLD<span class="accent">PRO</span></div>
+      <nav class="site-nav">
+        <a href="index.html">Главная</a>
+        <a href="services.html">Услуги</a>
+        <a href="about.html">О компании</a>
+        <a href="contacts.html">Контакты</a>
+        <a href="admin.html">Админ</a>
+      </nav>
+      <div class="burger" id="burger">
+        <span></span><span></span><span></span>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="services">
+      <div class="container">
+        <h1 class="section-title">Наши услуги</h1>
+        <div id="servicesList" class="cards"></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-flex">
+      <p>&copy; 2025 MoldPro. Все права защищены.</p>
+      <a href="#">Политика конфиденциальности</a>
+      <a href="tel:+7XXXXXXXXXX" class="footer-call btn accent">Позвонить</a>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,11 @@
 :root {
-  --bg: #111;
-  --bg-light: #1b1b1b;
-  --text: #f2f2f2;
-  --accent: #ff4d00;
-  --gray: #888;
-  --radius: 12px;
-  --transition: 0.3s ease;
+  --bg: #ffffff;
+  --bg-light: #f7f7f7;
+  --text: #333333;
+  --accent: #0055aa;
+  --gray: #666666;
+  --radius: 8px;
+  --transition: 0.2s ease;
 }
 
 *,
@@ -65,10 +65,11 @@ img, video { max-width: 100%; display: block; }
 .accent { color: var(--accent); }
 
 .site-header {
-  background: rgba(0,0,0,0.8);
+  background: rgba(255,255,255,0.9);
   position: fixed; top: 0; left: 0; width: 100%; z-index: 1000;
   backdrop-filter: blur(6px);
   padding: 0.5rem 0;
+  border-bottom: 1px solid var(--bg-light);
 }
 
 .logo { font-weight: 700; font-size: 1.5rem; }
@@ -104,7 +105,7 @@ img, video { max-width: 100%; display: block; }
   position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover;
 }
 .overlay {
-  position: absolute; inset: 0; background: rgba(0,0,0,0.5);
+  position: absolute; inset: 0; background: rgba(0,0,0,0.3);
 }
 .hero-content {
   position: relative; z-index: 2;
@@ -175,12 +176,12 @@ img, video { max-width: 100%; display: block; }
 
 .contact-form { display: flex; flex-direction: column; gap: 1rem; }
 .contact-form input, .contact-form textarea {
-  background: #000; border: 1px solid #333; padding: 0.75rem; border-radius: var(--radius); color: var(--text);
+  background: #fff; border: 1px solid var(--bg-light); padding: 0.75rem; border-radius: var(--radius); color: var(--text);
 }
 .file-label { display: inline-block; cursor: pointer; }
 .file-label input { display: none; }
 
-.site-footer { background: #000; padding: 1.5rem 0; }
+.site-footer { background: var(--bg-light); padding: 1.5rem 0; }
 .footer-flex { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem; }
 .footer-call { background: transparent; border: 1px solid var(--accent); }
 


### PR DESCRIPTION
## Summary
- Split single-page site into home, services, about, contacts and admin pages
- Added admin panel to append services that render dynamically on the services page
- Replaced dark theme with a light, minimal color scheme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936619d9d4832c933aab3920f9427d